### PR TITLE
Rename BGG Mini-Expansion

### DIFF
--- a/src/data/products.json
+++ b/src/data/products.json
@@ -7,5 +7,5 @@
 	{ "pid": "mini4", "order": 6, "image": "images/products/mini4.png", "name": "Mini-Expansion 4: Final Bosses" },
 	{ "pid": "mini5", "order": 7, "image": "images/products/mini5.png", "name": "Mini-Expansion 5: Futures" },
 	{ "pid": "mini6", "order": 8, "image": "images/products/mini6.png", "name": "Mini-Expansion 6: Professionals" },
-	{ "pid": "mini7", "order": 9, "image": "images/products/mini7.png", "name": "Mini-Expansion 7: BoardGameGeek" }
+	{ "pid": "bgg1", "order": 9, "image": "images/products/bgg1.png", "name":  "BoardGameGeek Mini Expansion" }
 ]


### PR DESCRIPTION
Collusion Kickstarter will also introduce official Mini-Expansions, including one #7.